### PR TITLE
Add monitoring hooks and harden Triton runtime setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# Use Python 3.10 slim image as base
 FROM python:3.11.13-slim
 
 # Set working directory
@@ -11,17 +10,19 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv (fast Python package installer)
+# Install uv
 RUN pip install --no-cache-dir uv
 
 # Copy dependency files
 COPY pyproject.toml uv.lock* ./
 
-# Install Python dependencies directly (not editable to avoid README requirement)
+# Install Python dependencies directly
 # Note: We'll use CPU-only PyTorch for Docker to reduce image size
 # Split install to avoid huge layer commit fails
 RUN uv pip install --system --no-cache \
-    torch --index-url https://download.pytorch.org/whl/cpu
+    torch \
+    torchvision \
+    --index-url https://download.pytorch.org/whl/cpu
 
 RUN uv pip install --system --no-cache \
     transformers \
@@ -34,7 +35,9 @@ RUN uv pip install --system --no-cache \
     tqdm \
     onnx \
     onnxruntime \
-    tritonclient[http]
+    tritonclient[http] \
+    google-genai \
+    prometheus-client
 
 # Copy application code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ curl -X POST http://localhost:7860/predict \
 
 For detailed API documentation with code examples in Python, JavaScript, and more, see **[docs/API_USAGE.md](docs/API_USAGE.md)**.
 
+## 📈 Monitoring and Load Generation
+
+This repository includes Docker Compose services for Prometheus and Grafana, plus Triton metrics on port `8002`.
+
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3000`
+- Triton metrics: `http://localhost:8002/metrics`
+
+To make dashboards useful, send repeated requests using the real SROIE sample images and OCR files under `data/SROIE2019/test/`.
+
+For Prometheus setup, traffic generation examples, and recommended Grafana panels, see **[docs/MONITORING.md](docs/MONITORING.md)**.
+
 ## 🔧 Configuration
 
 ### Using .env File (Recommended)

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import os
 import logging
 from dotenv import load_dotenv
 import gradio as gr
+from fastapi.responses import RedirectResponse
 from src import app, create_gradio_interface, load_model, DEVICE, MODEL_PATH
 
 load_dotenv()
@@ -28,8 +29,13 @@ logger = logging.getLogger(__name__)
 demo = create_gradio_interface()
 
 
-# Mount Gradio app to FastAPI
-app = gr.mount_gradio_app(app, demo, path="/")
+# Mount Gradio under a dedicated path so API and metrics routes stay reachable
+app = gr.mount_gradio_app(app, demo, path="/ui")
+
+
+@app.get("/", include_in_schema=False)
+async def root_redirect():
+    return RedirectResponse(url="/ui")
 
 
 # ============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,34 @@ services:
           cpus: '${TRITON_CPU_LIMIT:-4}'
           memory: ${TRITON_MEMORY_LIMIT:-8G}
 
+  prometheus:
+    image: prom/prometheus:v2.45.0
+    container_name: prometheus
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/prometheus/alert.rules:/etc/prometheus/alert.rules
+    ports:
+      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+
+  grafana:
+    image: grafana/grafana:10.1.0
+    container_name: grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+
 networks:
   default:
     name: invoice-ner-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   invoice-ner:
     build:

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,309 @@
+# Monitoring and Traffic Generation
+
+This guide covers:
+
+- generating load with real SROIE samples
+- scraping Triton metrics with Prometheus
+- building useful Grafana panels for inference serving
+
+## Overview
+
+In this project, the main monitoring target is Triton Inference Server, not the FastAPI app.
+
+- Triton HTTP inference: `localhost:8000`
+- Triton metrics: `localhost:8002/metrics`
+- Prometheus UI: `http://localhost:9090`
+- Grafana UI: `http://localhost:3000`
+
+When Prometheus runs inside Docker Compose, it should scrape:
+
+```yaml
+- job_name: 'tritonserver'
+  metrics_path: /metrics
+  static_configs:
+    - targets: ['tritonserver:8002']
+```
+
+Do not use `localhost:8002` inside the Prometheus container unless Prometheus itself is running on the host.
+
+## Start the Monitoring Stack
+
+Run the full stack:
+
+```bash
+docker compose up -d --build
+```
+
+Then verify:
+
+```bash
+curl http://localhost:7860/health
+curl http://localhost:8002/metrics
+```
+
+Open Prometheus targets:
+
+```text
+http://localhost:9090/targets
+```
+
+The `tritonserver` target should be `UP`.
+
+## Generate Traffic with Real Data
+
+To make Prometheus and Grafana useful, you need sustained inference traffic. Use the real SROIE dataset already present in:
+
+- `data/SROIE2019/test/img`
+- `data/SROIE2019/test/box`
+
+### Quick Single Request
+
+```bash
+curl -X POST http://localhost:7860/predict \
+  -F "image=@data/SROIE2019/test/img/X51005675104.jpg" \
+  -F "ocr_file=@data/SROIE2019/test/box/X51005675104.txt"
+```
+
+### Simple Replay Loop
+
+This sends repeated requests using real image and OCR pairs:
+
+```bash
+for f in data/SROIE2019/test/img/*.jpg; do
+  base=$(basename "$f" .jpg)
+  curl -s -X POST http://localhost:7860/predict \
+    -F "image=@${f}" \
+    -F "ocr_file=@data/SROIE2019/test/box/${base}.txt" > /dev/null
+done
+```
+
+### Sustained Load
+
+Use a loop to keep traffic flowing while watching dashboards:
+
+```bash
+while true; do
+  for f in data/SROIE2019/test/img/*.jpg; do
+    base=$(basename "$f" .jpg)
+    curl -s -X POST http://localhost:7860/predict \
+      -F "image=@${f}" \
+      -F "ocr_file=@data/SROIE2019/test/box/${base}.txt" > /dev/null
+  done
+done
+```
+
+If you want higher throughput, run multiple terminals with the same loop.
+
+## Prometheus: Useful Triton Metrics
+
+The main Triton metrics exposed by this stack are:
+
+- `nv_inference_request_success`
+- `nv_inference_request_failure`
+- `nv_inference_count`
+- `nv_inference_exec_count`
+- `nv_inference_request_duration_us`
+- `nv_inference_queue_duration_us`
+- `nv_inference_compute_input_duration_us`
+- `nv_inference_compute_infer_duration_us`
+- `nv_inference_compute_output_duration_us`
+- `nv_inference_pending_request_count`
+- `nv_cpu_utilization`
+- `nv_cpu_memory_total_bytes`
+- `nv_cpu_memory_used_bytes`
+
+These duration metrics are cumulative counters, so use `rate(...)` and divide by request volume to get average durations.
+
+## Grafana Panels
+
+Create a dashboard in Grafana and add the following panels with the `Prometheus` datasource.
+
+### Request Rate
+
+Type: Time series
+
+```promql
+sum(rate(nv_inference_request_success[1m])) by (model, version)
+```
+
+Unit: `req/s`
+
+### Failure Rate
+
+Type: Time series
+
+```promql
+sum(rate(nv_inference_request_failure[1m])) by (model, version)
+```
+
+Unit: `req/s`
+
+### Error Percentage
+
+Type: Time series
+
+```promql
+100 * sum(rate(nv_inference_request_failure[5m])) by (model, version)
+/
+clamp_min(
+  sum(rate(nv_inference_request_success[5m]) + rate(nv_inference_request_failure[5m])) by (model, version),
+  1e-9
+)
+```
+
+Unit: `percent (0-100)`
+
+### Average Request Latency
+
+Type: Time series
+
+```promql
+(
+  sum(rate(nv_inference_request_duration_us[5m])) by (model, version)
+  /
+  clamp_min(sum(rate(nv_inference_request_success[5m])) by (model, version), 1e-9)
+) / 1000
+```
+
+Unit: `ms`
+
+### Average Queue Latency
+
+Type: Time series
+
+```promql
+(
+  sum(rate(nv_inference_queue_duration_us[5m])) by (model, version)
+  /
+  clamp_min(sum(rate(nv_inference_request_success[5m])) by (model, version), 1e-9)
+) / 1000
+```
+
+Unit: `ms`
+
+### Average Input Time
+
+Type: Time series
+
+```promql
+(
+  sum(rate(nv_inference_compute_input_duration_us[5m])) by (model, version)
+  /
+  clamp_min(sum(rate(nv_inference_count[5m])) by (model, version), 1e-9)
+) / 1000
+```
+
+Unit: `ms`
+
+### Average Infer Time
+
+Type: Time series
+
+```promql
+(
+  sum(rate(nv_inference_compute_infer_duration_us[5m])) by (model, version)
+  /
+  clamp_min(sum(rate(nv_inference_count[5m])) by (model, version), 1e-9)
+) / 1000
+```
+
+Unit: `ms`
+
+### Average Output Time
+
+Type: Time series
+
+```promql
+(
+  sum(rate(nv_inference_compute_output_duration_us[5m])) by (model, version)
+  /
+  clamp_min(sum(rate(nv_inference_count[5m])) by (model, version), 1e-9)
+) / 1000
+```
+
+Unit: `ms`
+
+### Pending Requests
+
+Type: Time series
+
+```promql
+nv_inference_pending_request_count
+```
+
+### Inferences Per Second
+
+Type: Time series
+
+```promql
+sum(rate(nv_inference_count[1m])) by (model, version)
+```
+
+Unit: `infer/s`
+
+### Execution Rate
+
+Type: Time series
+
+```promql
+sum(rate(nv_inference_exec_count[1m])) by (model, version)
+```
+
+Unit: `exec/s`
+
+### CPU Utilization
+
+Type: Time series
+
+```promql
+nv_cpu_utilization * 100
+```
+
+Unit: `percent (0-100)`
+
+### CPU Memory Used
+
+Type: Time series
+
+```promql
+nv_cpu_memory_used_bytes
+```
+
+Unit: `bytes`
+
+### CPU Memory Utilization
+
+Type: Time series
+
+```promql
+100 * nv_cpu_memory_used_bytes / nv_cpu_memory_total_bytes
+```
+
+Unit: `percent (0-100)`
+
+## Suggested Dashboard Layout
+
+Top row:
+
+- request rate
+- failure rate
+- error percentage
+- pending requests
+
+Middle row:
+
+- average request latency
+- average queue latency
+- average infer time
+
+Bottom row:
+
+- CPU utilization
+- CPU memory used
+- CPU memory utilization
+
+## Notes
+
+- These metrics support averages, not p95/p99 latency, because Triton is exporting cumulative duration counters rather than histogram buckets.
+- If request rate rises and queue latency rises first, the server is saturating before model compute becomes the bottleneck.
+- Save important Grafana dashboards back into `monitoring/grafana/dashboards/` if you want them version-controlled.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,13 @@ Testing guide and validation documentation:
 - CI/CD integration
 - Best practices
 
+### 📈 [MONITORING.md](./MONITORING.md)
+Monitoring and load-generation guide:
+- Prometheus and Grafana setup
+- Triton metrics to watch
+- Real-data traffic generation
+- Recommended Grafana panels
+
 ## Quick Links
 
 ### For Developers
@@ -35,11 +42,13 @@ Testing guide and validation documentation:
 - **Setup Environment**: [DEV_SETUP.md](./DEV_SETUP.md)
 - **API Docs**: [API_USAGE.md](./API_USAGE.md)
 - **Run Tests**: [TESTING.md](./TESTING.md)
+- **Monitoring**: [MONITORING.md](./MONITORING.md)
 
 ### For Production
 - **API Reference**: [API_USAGE.md](./API_USAGE.md)
 - **Testing & Validation**: [TESTING.md](./TESTING.md)
 - **Docker Deployment**: See main [README.md](../README.md)
+- **Monitoring & Dashboards**: [MONITORING.md](./MONITORING.md)
 
 ### For Research
 - **Benchmarking**: [../benchmarks/README.md](../benchmarks/README.md)
@@ -53,6 +62,7 @@ docs/
 ├── README.md                   # This file
 ├── API_USAGE.md                # API documentation
 ├── DEV_SETUP.md                # Development setup
+├── MONITORING.md               # Monitoring and traffic guide
 └── TESTING.md                  # Testing guide
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pillow>=11.3.0",
     "tqdm>=4.67.1",
     "torch",
+    "torchvision",
     "transformers",
     "numpy>=1.24.0",
     # Web app dependencies

--- a/src/api.py
+++ b/src/api.py
@@ -7,13 +7,16 @@ import os
 import json
 import tempfile
 import logging
+import time
 from typing import List
 from contextlib import asynccontextmanager
 from PIL import Image
 from fastapi import FastAPI, File, UploadFile, HTTPException
 from pydantic import BaseModel
+from prometheus_client import make_asgi_app
 
 from . import inference
+from . import monitoring
 from .heuristics import extract_invoice_heuristics
 from .postprocessing import postprocess_invoice_number
 from .validation import validate_model_extraction
@@ -41,6 +44,9 @@ app = FastAPI(
     description="Finetuned LayoutLMv3 model for extracting invoice numbers",
     lifespan=lifespan,
 )
+
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
 
 
 class PredictionRequest(BaseModel):
@@ -159,6 +165,7 @@ def predict(
         logger.info("=" * 60)
 
         # Step 1: Try heuristics first
+        start_time = time.time()
         invoice_number, matched_indices = extract_invoice_heuristics(words, ocr_lines)
 
         if invoice_number:
@@ -170,6 +177,13 @@ def predict(
                 for i in range(len(words))
             ]
             confidence_scores = [1.0] * len(words)
+
+            monitoring.record_inference_metrics(
+                method="heuristic",
+                status="success",
+                duration=time.time() - start_time,
+            )
+
         else:
             # Step 2: Fall back to model
             extraction_method = "model"

--- a/src/inference.py
+++ b/src/inference.py
@@ -7,11 +7,17 @@ import logging
 import numpy as np
 from PIL import Image
 from typing import List, Dict
-from transformers import LayoutLMv3Processor
+from transformers import (
+    LayoutLMv3ImageProcessor,
+    LayoutLMv3Processor,
+    LayoutLMv3TokenizerFast,
+)
 import onnxruntime as ort
 from abc import ABC, abstractmethod
+import time
 import tritonclient.http as httpclient
 from .gemini import GeminiClient
+from . import monitoring
 
 from .validation import validate_image, validate_words, validate_boxes
 
@@ -213,6 +219,48 @@ class TritonBackend(InferenceBackend):
 # ============================================================================
 
 
+def _build_layoutlmv3_processor(processor_path: str) -> LayoutLMv3Processor:
+    """Load LayoutLMv3 processor with a compatibility fallback for newer transformers."""
+    try:
+        return LayoutLMv3Processor.from_pretrained(processor_path, apply_ocr=False)
+    except Exception as exc:
+        if not os.path.isdir(processor_path):
+            raise
+
+        logger.warning(
+            "Falling back to manual LayoutLMv3 processor assembly for %s: %s",
+            processor_path,
+            exc,
+        )
+        image_processor = LayoutLMv3ImageProcessor.from_pretrained(
+            processor_path, apply_ocr=False
+        )
+        tokenizer = LayoutLMv3TokenizerFast.from_pretrained(processor_path)
+        return LayoutLMv3Processor(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+        )
+
+
+def _processor_candidates(model_path: str, processor_path: str) -> List[str]:
+    candidates = []
+    seen = set()
+
+    for candidate in (
+        processor_path,
+        os.path.dirname(model_path) if os.path.isfile(model_path) else None,
+        "models/artifacts",
+        "models/layoutlmv3-lora-invoice-number",
+        BASE_MODEL,
+    ):
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        candidates.append(candidate)
+
+    return candidates
+
+
 def load_model():
     """Load the model (backend) and processor"""
     global processor, backend
@@ -235,13 +283,20 @@ def load_model():
         print(f"⚠️ MODEL_PATH {model_path} not found.")
 
     # Load processor
-    try:
-        processor = LayoutLMv3Processor.from_pretrained(processor_path, apply_ocr=False)
-        print(f"✅ Processor loaded from {processor_path}")
-    except Exception as e:
-        print(f"⚠️ Could not load processor from {processor_path}: {e}")
-        print(f"   Falling back to base model: {BASE_MODEL}")
-        processor = LayoutLMv3Processor.from_pretrained(BASE_MODEL, apply_ocr=False)
+    processor_errors = []
+    for candidate in _processor_candidates(model_path, processor_path):
+        try:
+            processor = _build_layoutlmv3_processor(candidate)
+            print(f"✅ Processor loaded from {candidate}")
+            break
+        except Exception as e:
+            processor_errors.append(f"{candidate}: {e}")
+            print(f"⚠️ Could not load processor from {candidate}: {e}")
+    else:
+        raise RuntimeError(
+            "Failed to load LayoutLMv3 processor from any known location. Errors: "
+            + " | ".join(processor_errors)
+        )
 
     # Initialize Backend
     print(f"👉 Initializing Inference Backend: {INFERENCE_BACKEND.upper()}")
@@ -279,6 +334,8 @@ def predict_invoice(
     """
     Run inference on invoice using the configured backend
     """
+    start_time = time.time()
+
     # Validate model loaded
     if backend is None or processor is None:
         raise ValueError("Model not loaded. Call load_model() first.")
@@ -299,6 +356,8 @@ def predict_invoice(
         return_tensors="np",
     )
 
+    num_tokens = np.sum(encoding["attention_mask"])
+
     # Prepare inputs dictionary
     inputs = {
         "pixel_values": encoding["pixel_values"],
@@ -312,6 +371,9 @@ def predict_invoice(
         logits = backend.predict(inputs)
     except Exception as e:
         logger.error(f"Primary model failed: {e}")
+        monitoring.record_error(type(e).__name__)
+        monitoring.record_fallback("model_failure", "gemini")
+
         logger.info("🔄 Attempting fallback to Gemini...")
 
         if gemini_client:
@@ -340,6 +402,7 @@ def predict_invoice(
                 }
             else:
                 # Gemini returned nothing
+                monitoring.record_error("GeminiEmptyResult")
                 logger.warning("Gemini found no invoice number.")
                 raise e
         else:
@@ -409,6 +472,23 @@ def predict_invoice(
 
     # Combine invoice tokens
     invoice_number = " ".join(invoice_tokens) if invoice_tokens else None
+
+    avg_conf = 0.0
+    if invoice_tokens:
+        relevant_confs = [
+            conf
+            for conf, label in zip(word_confidences, predicted_labels)
+            if label in ["LABEL_1", "LABEL_2"]
+        ]
+        if relevant_confs:
+            avg_conf = sum(relevant_confs) / len(relevant_confs)
+
+    monitoring.record_ml_metrics(avg_conf, int(num_tokens))
+    monitoring.record_inference_metrics(
+        method="model",
+        status="success",
+        duration=time.time() - start_time,
+    )
 
     return {
         "words": words[: len(predicted_labels)],

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -1,0 +1,114 @@
+import os
+import logging
+from prometheus_client import Counter, Histogram
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = os.getenv("TRITON_MODEL_NAME", "layoutlmv3-lora-invoice-number")
+MODEL_VERSION = os.getenv("TRITON_MODEL_VERSION", "1")
+ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
+
+_LABELS = ["method", "status", "model_name", "model_version", "environment"]
+
+INFERENCE_REQUESTS_TOTAL = Counter(
+    "inference_requests_total",
+    "Total number of inference requests processed",
+    _LABELS,
+)
+
+INFERENCE_ERRORS_TOTAL = Counter(
+    "inference_errors_total",
+    "Total number of failed inference requests",
+    ["error_type", "model_name", "model_version", "environment"],
+)
+
+INFERENCE_LATENCY_SECONDS = Histogram(
+    "inference_latency_seconds",
+    "Time taken for inference (seconds)",
+    ["method", "model_name", "model_version", "environment"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, float("inf")),
+)
+
+PREDICTION_CONFIDENCE = Histogram(
+    "prediction_confidence",
+    "Confidence score of the prediction (0-1)",
+    ["model_name", "model_version", "environment"],
+    buckets=(
+        0.0,
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+        0.85,
+        0.9,
+        0.95,
+        0.98,
+        0.99,
+        1.0,
+    ),
+)
+
+INPUT_TOKEN_COUNT = Histogram(
+    "input_token_count",
+    "Number of tokens in the input",
+    ["model_name", "model_version", "environment"],
+    buckets=(0, 64, 128, 256, 384, 512, 768, 1024),
+)
+
+FALLBACK_TOTAL = Counter(
+    "fallback_total",
+    "Total number of fallbacks triggered",
+    ["trigger_reason", "target_backend", "environment"],
+)
+
+
+def record_inference_metrics(method: str, status: str, duration: float) -> None:
+    INFERENCE_REQUESTS_TOTAL.labels(
+        method=method,
+        status=status,
+        model_name=MODEL_NAME,
+        model_version=MODEL_VERSION,
+        environment=ENVIRONMENT,
+    ).inc()
+
+    INFERENCE_LATENCY_SECONDS.labels(
+        method=method,
+        model_name=MODEL_NAME,
+        model_version=MODEL_VERSION,
+        environment=ENVIRONMENT,
+    ).observe(duration)
+
+
+def record_error(error_type: str) -> None:
+    INFERENCE_ERRORS_TOTAL.labels(
+        error_type=error_type,
+        model_name=MODEL_NAME,
+        model_version=MODEL_VERSION,
+        environment=ENVIRONMENT,
+    ).inc()
+
+
+def record_ml_metrics(confidence: float, token_count: int) -> None:
+    PREDICTION_CONFIDENCE.labels(
+        model_name=MODEL_NAME,
+        model_version=MODEL_VERSION,
+        environment=ENVIRONMENT,
+    ).observe(confidence)
+
+    INPUT_TOKEN_COUNT.labels(
+        model_name=MODEL_NAME,
+        model_version=MODEL_VERSION,
+        environment=ENVIRONMENT,
+    ).observe(token_count)
+
+
+def record_fallback(reason: str, target: str) -> None:
+    FALLBACK_TOTAL.labels(
+        trigger_reason=reason,
+        target_backend=target,
+        environment=ENVIRONMENT,
+    ).inc()

--- a/uv.lock
+++ b/uv.lock
@@ -1941,6 +1941,7 @@ dependencies = [
     { name = "pillow" },
     { name = "python-dotenv" },
     { name = "torch" },
+    { name = "torchvision" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "tritonclient", extra = ["http"] },
@@ -1993,6 +1994,7 @@ requires-dist = [
     { name = "seqeval", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "streamlit", marker = "extra == 'dev'", specifier = ">=1.49.1" },
     { name = "torch" },
+    { name = "torchvision" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers" },
     { name = "tritonclient", extras = ["http"], specifier = ">=2.41.0" },
@@ -5050,6 +5052,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/15/5e488ca0bc6162c86a33b58642bc577c84ded17c7b72d97e49b5833e2d73/torch-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8f0a9d617a66509ded240add3754e462430a6c1fc5589f86c17b433dd808f97a", size = 887990692, upload-time = "2025-08-06T14:56:18.286Z" },
     { url = "https://files.pythonhosted.org/packages/b4/a8/6a04e4b54472fc5dba7ca2341ab219e529f3c07b6941059fbf18dccac31f/torch-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a7242b86f42be98ac674b88a4988643b9bc6145437ec8f048fea23f72feb5eca", size = 241603453, upload-time = "2025-08-06T14:55:22.945Z" },
     { url = "https://files.pythonhosted.org/packages/04/6e/650bb7f28f771af0cb791b02348db8b7f5f64f40f6829ee82aa6ce99aabe/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7b677e17f5a3e69fdef7eb3b9da72622f8d322692930297e4ccb52fefc6c8211", size = 73632395, upload-time = "2025-08-06T14:55:28.645Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/49/5ad5c3ff4920be0adee9eb4339b4fb3b023a0fc55b9ed8dbc73df92946b8/torchvision-0.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7266871daca00ad46d1c073e55d972179d12a58fa5c9adec9a3db9bbed71284a", size = 1856885, upload-time = "2025-08-06T14:57:55.024Z" },
+    { url = "https://files.pythonhosted.org/packages/25/44/ddd56d1637bac42a8c5da2c8c440d8a28c431f996dd9790f32dd9a96ca6e/torchvision-0.23.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:31c583ba27426a3a04eca8c05450524105c1564db41be6632f7536ef405a6de2", size = 2394251, upload-time = "2025-08-06T14:58:01.725Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f3/3cdf55bbf0f737304d997561c34ab0176222e0496b6743b0feab5995182c/torchvision-0.23.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:3932bf67256f2d095ce90a9f826f6033694c818856f4bb26794cf2ce64253e53", size = 8627497, upload-time = "2025-08-06T14:58:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/97/90/02afe57c3ef4284c5cf89d3b7ae203829b3a981f72b93a7dd2a3fd2c83c1/torchvision-0.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:83ee5bf827d61a8af14620c0a61d8608558638ac9c3bac8adb7b27138e2147d1", size = 1600760, upload-time = "2025-08-06T14:57:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d7/15d3d7bd8d0239211b21673d1bac7bc345a4ad904a8e25bb3fd8a9cf1fbc/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:49aa20e21f0c2bd458c71d7b449776cbd5f16693dd5807195a820612b8a229b7", size = 1856884, upload-time = "2025-08-06T14:58:00.237Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/7b44fe766b7d11e064c539d92a172fa9689a53b69029e24f2f1f51e7dc56/torchvision-0.23.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:01dc33ee24c79148aee7cdbcf34ae8a3c9da1674a591e781577b716d233b1fa6", size = 2395543, upload-time = "2025-08-06T14:58:04.373Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fcb09aff941c8147d9e6aa6c8f67412a05622b0c750bcf796be4c85a58d4/torchvision-0.23.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:35c27941831b653f5101edfe62c03d196c13f32139310519e8228f35eae0e96a", size = 8628388, upload-time = "2025-08-06T14:58:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/93/40/3415d890eb357b25a8e0a215d32365a88ecc75a283f75c4e919024b22d97/torchvision-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:09bfde260e7963a15b80c9e442faa9f021c7e7f877ac0a36ca6561b367185013", size = 1600741, upload-time = "2025-08-06T14:57:59.158Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885, upload-time = "2025-08-06T14:58:06.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/00/2f6454decc0cd67158c7890364e446aad4b91797087a57a78e72e1a8f8bc/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", size = 2396614, upload-time = "2025-08-06T14:58:03.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b5/3e580dcbc16f39a324f3dd71b90edbf02a42548ad44d2b4893cc92b1194b/torchvision-0.23.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4e7d31c43bc7cbecbb1a5652ac0106b436aa66e26437585fc2c4b2cf04d6014c", size = 8627108, upload-time = "2025-08-06T14:58:12.956Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c1/c2fe6d61e110a8d0de2f94276899a2324a8f1e6aee559eb6b4629ab27466/torchvision-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2e45272abe7b8bf0d06c405e78521b5757be1bd0ed7e5cd78120f7fdd4cbf35", size = 1600723, upload-time = "2025-08-06T14:57:57.986Z" },
+    { url = "https://files.pythonhosted.org/packages/91/37/45a5b9407a7900f71d61b2b2f62db4b7c632debca397f205fdcacb502780/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600", size = 1856886, upload-time = "2025-08-06T14:58:05.491Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/da/a06c60fc84fc849377cf035d3b3e9a1c896d52dbad493b963c0f1cdd74d0/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d", size = 2353112, upload-time = "2025-08-06T14:58:26.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/27/5ce65ba5c9d3b7d2ccdd79892ab86a2f87ac2ca6638f04bb0280321f1a9c/torchvision-0.23.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a76fafe113b2977be3a21bf78f115438c1f88631d7a87203acb3dd6ae55889e6", size = 8627658, upload-time = "2025-08-06T14:58:15.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e4/028a27b60aa578a2fa99d9d7334ff1871bb17008693ea055a2fdee96da0d/torchvision-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:07d069cb29691ff566e3b7f11f20d91044f079e1dbdc9d72e0655899a9b06938", size = 1600749, upload-time = "2025-08-06T14:58:10.719Z" },
+    { url = "https://files.pythonhosted.org/packages/05/35/72f91ad9ac7c19a849dedf083d347dc1123f0adeb401f53974f84f1d04c8/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9", size = 2047192, upload-time = "2025-08-06T14:58:11.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9d/406cea60a9eb9882145bcd62a184ee61e823e8e1d550cdc3c3ea866a9445/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b", size = 2359295, upload-time = "2025-08-06T14:58:17.469Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f4/34662f71a70fa1e59de99772142f22257ca750de05ccb400b8d2e3809c1d/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:76bc4c0b63d5114aa81281390f8472a12a6a35ce9906e67ea6044e5af4cab60c", size = 8800474, upload-time = "2025-08-06T14:58:22.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/b5a2d841a8d228b5dbda6d524704408e19e7ca6b7bb0f24490e081da1fa1/torchvision-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b9e2dabf0da9c8aa9ea241afb63a8f3e98489e706b22ac3f30416a1be377153b", size = 1527667, upload-time = "2025-08-06T14:58:14.446Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Prometheus monitoring hooks and a  endpoint
- add monitoring metrics collection for heuristic, model, and fallback paths
- harden LayoutLMv3 processor loading with local compatibility fallbacks
- add  runtime support for LayoutLMv3 image processing
- add monitoring and traffic-generation documentation

## Testing
- python3 -m py_compile app.py src/api.py src/inference.py
- python3 -m py_compile scripts/generate_traffic.py
- exercised Docker/Triton startup iteratively during integration
